### PR TITLE
fix attribute getter/setter syntax, comply to strict compiler

### DIFF
--- a/rellax.asc
+++ b/rellax.asc
@@ -237,132 +237,132 @@ void _set_targetcharacter(Character* target) {
 
 // ---- Rellax API ------------------------------------------------------------
 
-void set_TargetCharacter(this Rellax*, Character* target)
+void set_TargetCharacter(static Rellax, Character* target)
 {
   _set_targetcharacter(target);
 }
 
-Character* get_TargetCharacter(this Rellax*)
+Character* get_TargetCharacter(static Rellax)
 {
   return  _TargetCharacter;
 }
 
-void set_EnableParallax(this Rellax*, bool enable)
+void set_EnableParallax(static Rellax, bool enable)
 { 
   _enable_parallax(enable);
 }
 
-bool get_EnableParallax(this Rellax*)
+bool get_EnableParallax(static Rellax)
 {
   return _ParallaxEnabled;
 }
 
-void set_EnableSmoothCam(this Rellax*, bool enable)
+void set_EnableSmoothCam(static Rellax, bool enable)
 { 
   _enable_smoothcam(enable);
 }
 
-bool get_EnableSmoothCam(this Rellax*)
+bool get_EnableSmoothCam(static Rellax)
 {
   return _SmoothCamEnabled;
 }
 
-void set_AdjustCameraOnRoomLoad(this Rellax*, bool enable)
+void set_AdjustCameraOnRoomLoad(static Rellax, bool enable)
 { 
   _AdjustCameraOnRoomLoad = enable;
 }
 
-bool get_AdjustCameraOnRoomLoad(this Rellax*)
+bool get_AdjustCameraOnRoomLoad(static Rellax)
 {
   return _AdjustCameraOnRoomLoad;
 }
 
-void set_CameraOffsetX(this Rellax*, int offset_x)
+void set_CameraOffsetX(static Rellax, int offset_x)
 { 
   _off_x = offset_x;
 }
 
-int get_CameraOffsetX(this Rellax*)
+int get_CameraOffsetX(static Rellax)
 {
   return _off_x;
 }
 
-void set_CameraOffsetY(this Rellax*, int offset_y)
+void set_CameraOffsetY(static Rellax, int offset_y)
 { 
   _off_y = offset_y;
 }
 
-int get_CameraOffsetY(this Rellax*)
+int get_CameraOffsetY(static Rellax)
 {
   return _off_y;
 }
 
-void set_CameraLookAheadX(this Rellax*, int look_ahead_x)
+void set_CameraLookAheadX(static Rellax, int look_ahead_x)
 { 
   _look_ahead_x = look_ahead_x;
 }
 
-int get_CameraLookAheadX(this Rellax*)
+int get_CameraLookAheadX(static Rellax)
 {
   return _look_ahead_x;
 }
 
-void set_CameraLookAheadY(this Rellax*, int look_ahead_y)
+void set_CameraLookAheadY(static Rellax, int look_ahead_y)
 { 
   _look_ahead_y = look_ahead_y;
 }
 
-int get_CameraLookAheadY(this Rellax*)
+int get_CameraLookAheadY(static Rellax)
 {
   return _look_ahead_y;
 }
 
-void set_StandstillCameraDelayY(this Rellax*, int value)
+void set_StandstillCameraDelayY(static Rellax, int value)
 { 
   _standstill_ticks_y = value;
 }
 
-int get_StandstillCameraDelayY(this Rellax*)
+int get_StandstillCameraDelayY(static Rellax)
 {
   return _standstill_ticks_y;
 }
 
-void set_CameraLerpFactorX(this Rellax*, float value)
+void set_CameraLerpFactorX(static Rellax, float value)
 { 
   _cam_lerp_factor_x = value;
 }
 
-float get_CameraLerpFactorX(this Rellax*)
+float get_CameraLerpFactorX(static Rellax)
 {
   return _cam_lerp_factor_x;
 }
 
-void set_CameraLerpFactorY(this Rellax*, float value)
+void set_CameraLerpFactorY(static Rellax, float value)
 { 
   _cam_lerp_factor_y = value;
 }
 
-float get_CameraLerpFactorY(this Rellax*)
+float get_CameraLerpFactorY(static Rellax)
 {
   return _cam_lerp_factor_y;
 }
 
-void set_CameraWindowWidth(this Rellax*, int value)
+void set_CameraWindowWidth(static Rellax, int value)
 { 
   _cam_window_w = value;
 }
 
-int get_CameraWindowWidth(this Rellax*)
+int get_CameraWindowWidth(static Rellax)
 {
   return _cam_window_w;
 }
 
-void set_CameraWindowHeight(this Rellax*, int value)
+void set_CameraWindowHeight(static Rellax, int value)
 { 
   _cam_window_h = value;
 }
 
-int get_CameraWindowHeight(this Rellax*)
+int get_CameraWindowHeight(static Rellax)
 {
   return _cam_window_h;
 }


### PR DESCRIPTION
This fixes static attributes' getters and setters to have following syntax:

```
void set_Attribute(static Rellax, other params)
```

This syntax is supported since AGS 3.4.0, and required by a new ags4 compiler, which is more strict, and does not allow to have a non-static function definition with initial static declaration.